### PR TITLE
Improve example section on demo

### DIFF
--- a/demo/entry.js
+++ b/demo/entry.js
@@ -195,10 +195,13 @@ const HtmlExample = () => {
 }
 
 const Css = () => {
-  const code = cxs.getCss()
+  const src = cxs.getCss()
+  let code = src
     .replace(/{/g, '{\n ')
     .replace(/;/g, ';\n ')
     .replace(/ +}/g, '}\n')
+  code = `/* ${src.replace(/\s{2,}/, '').length} bytes */
+code`
 
   return Example({
     heading: 'Generated CSS for this page',

--- a/demo/entry.js
+++ b/demo/entry.js
@@ -168,15 +168,7 @@ const Readme = () => {
   `
 }
 
-const prettifyCss = (css) => {
-  return css
-    .replace(/;/g, ';\n  ')
-    .replace(/{/g, ' {\n  ')
-    .replace(/}/g, '}\n')
-}
-
-const HtmlExample = () => {
-  const buttonHtml = Button({ text: 'Hello' }).outerHTML
+const Example = ({ heading, code, ...props }) => {
   const cx = {
     fontSize: 14,
     padding: 32,
@@ -185,33 +177,33 @@ const HtmlExample = () => {
   }
 
   return h`
-    <div css=${cx}>
-      <h3>Example HTML output</h3>
-      <pre>${buttonHtml}</pre>
+    <div css=${cx} ${props}>
+      <h3>${heading}</h3>
+      <pre>${code}</pre>
     </div>
   `
 }
 
+const HtmlExample = () => {
+  const code = Button({ text: 'Hello' }).outerHTML
+    .replace(/\s{5}/g, '\n')
+
+  return Example({
+    heading: 'Example HTML output',
+    code
+  })
+}
+
 const Css = () => {
-  const css = prettifyCss(cxs.css)
+  const code = cxs.getCss()
+    .replace(/{/g, '{\n ')
+    .replace(/;/g, ';\n ')
+    .replace(/ +}/g, '}\n')
 
-  const cx = {
-    root: {
-      padding: 32,
-      maxWidth: 640,
-      margin: 'auto'
-    },
-    pre: {
-    }
-  }
-
-  return h`
-    <div css=${cx.root}>
-      <h3>Generated CSS for this page</h3>
-      <pre css=${cx.pre}>/* ${cxs.css.length} bytes */
-${css}</pre>
-    </div>
-  `
+  return Example({
+    heading: 'Generated CSS for this page',
+    code
+  })
 }
 
 const App = ({ state, dispatch }) => {

--- a/demo/entry.js
+++ b/demo/entry.js
@@ -201,7 +201,7 @@ const Css = () => {
     .replace(/;/g, ';\n ')
     .replace(/ +}/g, '}\n')
   code = `/* ${src.replace(/\s{2,}/, '').length} bytes */
-code`
+${code}`
 
   return Example({
     heading: 'Generated CSS for this page',


### PR DESCRIPTION
- Updated regex’s more cleanly format the example code
- An abstraction of the example sections into `Example` blocks prevents repetition of styling/DOM

Before:
<img width="719" alt="screen shot 2017-01-07 at 2 19 02 am" src="https://cloud.githubusercontent.com/assets/5074763/21740294/c99f912e-d483-11e6-854d-1cb7eb788ace.png">

After:
<img width="694" alt="screen shot 2017-01-07 at 2 57 15 am" src="https://cloud.githubusercontent.com/assets/5074763/21740340/113c5534-d485-11e6-8d9a-21bf3c929db7.png">

→ Merge #2 first, or change [Line 198](https://github.com/lachlanjc/hyp/blob/exemplified/demo/entry.js#L198) to `cxs.css` until then.

#2 also fixes the `[object Object]` and switches to Atomic classes.